### PR TITLE
AbstractNeedleRuleBuilder: remove unused method

### DIFF
--- a/src/main/java/org/needle4j/injection/InjectionConfiguration.java
+++ b/src/main/java/org/needle4j/injection/InjectionConfiguration.java
@@ -226,7 +226,7 @@ public final class InjectionConfiguration {
     }
 
     public Entry<Object, Object> handleInjectionProvider(final Collection<InjectionProvider<?>> injectionProviders,
-            final InjectionTargetInformation injectionTargetInformation) {
+                                                         final InjectionTargetInformation injectionTargetInformation) {
 
         for (final InjectionProvider<?> provider : injectionProviders) {
 
@@ -243,14 +243,28 @@ public final class InjectionConfiguration {
     // TODO extract
     public static Class<? extends MockProvider> lookupMockProviderClass(final String mockProviderClassName) {
 
+        if (mockProviderClassName == null) {
+            return autoDetectMockProviderClass();
+        }
+
         try {
-            if (mockProviderClassName != null) {
-                final Class<MockProvider> mockProviderClass = ReflectionUtil.lookupClass(MockProvider.class,
-                        mockProviderClassName);
-                return mockProviderClass;
-            }
+            final Class<MockProvider> mockProviderClass = ReflectionUtil.lookupClass(MockProvider.class,
+                    mockProviderClassName);
+            return mockProviderClass;
         } catch (final Exception e) {
             throw new RuntimeException("could not load mock provider class: '" + mockProviderClassName + "'", e);
+        }
+    }
+
+    private static Class<? extends MockProvider> autoDetectMockProviderClass() {
+        List<String> providers = Arrays.asList("org.needle4j.mock.MockitoProvider", "org.needle4j.mock.EasyMockProvider");
+
+        for (String p: providers) {
+            try {
+                return ReflectionUtil.lookupClass(MockProvider.class, p);
+            } catch (Exception e) {
+                // ignored. provider not available due to missing dependencies.
+            }
         }
 
         throw new RuntimeException("no mock provider configured");

--- a/src/main/java/org/needle4j/junit/AbstractNeedleRuleBuilder.java
+++ b/src/main/java/org/needle4j/junit/AbstractNeedleRuleBuilder.java
@@ -54,11 +54,6 @@ public abstract class AbstractNeedleRuleBuilder<B, R extends NeedleTestcase> ext
         return (B) this;
     }
 
-    private Class<? extends MockProvider> getMockProviderClass(final NeedleConfiguration needleConfiguration) {
-        return mockProviderClass != null ? mockProviderClass : InjectionConfiguration
-                .lookupMockProviderClass(needleConfiguration.getMockProviderClassName());
-    }
-
     private Set<Class<Annotation>> getCustomInjectionAnnotations() {
         final Set<Class<Annotation>> annotations = new HashSet<Class<Annotation>>();
         for (final Class<?> annotationClass : withAnnotations) {

--- a/src/main/java/org/needle4j/mock/MockitoProvider.java
+++ b/src/main/java/org/needle4j/mock/MockitoProvider.java
@@ -17,6 +17,15 @@ import org.slf4j.LoggerFactory;
  */
 public class MockitoProvider implements MockProvider, SpyProvider {
 
+    static {
+        // fail fast if Mockito is not available.
+        try {
+            Class.forName("org.mockito.Mockito");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(MockitoProvider.class);
 
   public static final String SPY_ANNOTATION_FQN = "org.mockito.Spy";

--- a/src/test/java/org/needle4j/injection/InjectionConfigurationTest.java
+++ b/src/test/java/org/needle4j/injection/InjectionConfigurationTest.java
@@ -1,13 +1,11 @@
 package org.needle4j.injection;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
 import org.needle4j.mock.EasyMockProvider;
 import org.needle4j.mock.MockProvider;
 import org.needle4j.mock.MockitoProvider;
+
+import static org.junit.Assert.*;
 
 public class InjectionConfigurationTest {
 
@@ -20,13 +18,18 @@ public class InjectionConfigurationTest {
     }
 
     @Test
-    public void testLookupMockProviderClass() throws Exception {
+    public void canLookupMockitoProvider() throws Exception {
         assertNotNull(InjectionConfiguration.lookupMockProviderClass(MockitoProvider.class.getName()));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testLookupMockProviderClass_Null() throws Exception {
-        assertNull(InjectionConfiguration.lookupMockProviderClass(null));
+    @Test
+    public void canLookupEasyMockProvider() {
+        assertNotNull(InjectionConfiguration.lookupMockProviderClass(EasyMockProvider.class.getName()));
+    }
+
+    @Test
+    public void lookupMockProviderDefaultsToMockitoProvider() throws Exception {
+        assertEquals(MockitoProvider.class, InjectionConfiguration.lookupMockProviderClass(null));
     }
 
 }


### PR DESCRIPTION
https://github.com/needle4j/needle4j/issues/18

InjectionConfiguration: try to load MockProvider when no provider is explicitely configured
